### PR TITLE
feat: filter out catalogs with 'search' in their ID

### DIFF
--- a/packages/addon/lib/catalogAggregator.ts
+++ b/packages/addon/lib/catalogAggregator.ts
@@ -129,6 +129,19 @@ class NodeCatalogAggregator extends BaseCatalogAggregator {
 
       const manifest = await response.json();
 
+      // Filter out catalogs with 'search' in their ID as they don't contain content
+      const filteredCatalogs = manifest.catalogs
+        ? manifest.catalogs.filter(
+            (cat: { id: string }) => !cat.id.toLowerCase().includes('search')
+          )
+        : [];
+
+      if (manifest.catalogs && manifest.catalogs.length !== filteredCatalogs.length) {
+        console.log(
+          `Filtered out ${manifest.catalogs.length - filteredCatalogs.length} search catalogs from ${manifest.name}`
+        );
+      }
+
       // Extract the necessary information for our catalog manifest
       const catalogManifest: CatalogManifest = {
         id: manifest.id,
@@ -136,7 +149,7 @@ class NodeCatalogAggregator extends BaseCatalogAggregator {
         description: manifest.description || '',
         endpoint: endpoint,
         resources: manifest.resources || [],
-        catalogs: manifest.catalogs || [],
+        catalogs: filteredCatalogs,
         version: manifest.version || '0.0.1',
         types: manifest.types || [],
       };

--- a/packages/shared/catalogAggregator.ts
+++ b/packages/shared/catalogAggregator.ts
@@ -64,6 +64,17 @@ export abstract class BaseCatalogAggregator {
         return null;
       }
 
+      // Filter out catalogs with 'search' in their ID as they don't contain content
+      const filteredCatalogs = manifest.catalogs.filter(
+        (cat: { id: string }) => !cat.id.toLowerCase().includes('search')
+      );
+
+      if (manifest.catalogs.length !== filteredCatalogs.length) {
+        console.log(
+          `Filtered out ${manifest.catalogs.length - filteredCatalogs.length} search catalogs from ${manifest.name}`
+        );
+      }
+
       // Create a CatalogManifest object
       const catalogManifest: CatalogManifest = {
         id: manifest.id,
@@ -73,7 +84,7 @@ export abstract class BaseCatalogAggregator {
         version: manifest.version || '0.0.1',
         resources: manifest.resources || ['catalog'],
         types: manifest.types || ['movie', 'series'],
-        catalogs: manifest.catalogs || [],
+        catalogs: filteredCatalogs,
         idPrefixes: manifest.idPrefixes,
         behaviorHints: manifest.behaviorHints,
       };

--- a/packages/shared/manifestBuilder.ts
+++ b/packages/shared/manifestBuilder.ts
@@ -58,14 +58,19 @@ export function buildManifest(
       userCatalogs.forEach(source => {
         // Add catalogs from this source
         source.catalogs.forEach(catalog => {
-          manifest.catalogs.push({
-            id: `${source.id}:${catalog.id}`,
-            type: catalog.type,
-            name: `${catalog.name}`,
-          });
+          // Skip catalogs with 'search' in their ID as they don't contain content
+          if (!catalog.id.toLowerCase().includes('search')) {
+            manifest.catalogs.push({
+              id: `${source.id}:${catalog.id}`,
+              type: catalog.type,
+              name: `${catalog.name}`,
+            });
 
-          // Collect types for the manifest
-          allTypes.add(catalog.type);
+            // Collect types for the manifest
+            allTypes.add(catalog.type);
+          } else {
+            console.log(`Skipping catalog with search in ID: ${catalog.id}`);
+          }
         });
 
         // Collect resources from the source -


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Catalogs with IDs containing "search" are now excluded from manifests, ensuring they do not appear in catalog listings.
- **Chores**
	- Added logging to indicate when and how many "search" catalogs are filtered out from manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->