### PR TITLE
feat: implement cache invalidation and user cache management 

### DIFF
--- a/packages/cloudflare/index.ts
+++ b/packages/cloudflare/index.ts
@@ -126,6 +126,9 @@ app.get('/manifest.json', async c => {
       const addonInterface = await getAddonInterface(userId, c.env.DB as D1Database);
 
       c.header('Content-Type', 'application/json');
+      c.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+      c.header('Pragma', 'no-cache');
+      c.header('Expires', '0');
       return c.json(addonInterface.manifest);
     } catch (error) {
       console.error('Error generating manifest:', error);
@@ -154,6 +157,9 @@ app.get('/:params/manifest.json', async c => {
       const addonInterface = await getAddonInterface(userId, c.env.DB as D1Database);
 
       c.header('Content-Type', 'application/json');
+      c.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+      c.header('Pragma', 'no-cache');
+      c.header('Expires', '0');
       return c.json(addonInterface.manifest);
     } catch (error) {
       console.error('Error generating manifest:', error);
@@ -199,6 +205,9 @@ app.get('/:params/:resource/:type/:id\\.json', async c => {
         return c.json({ error: 'Resource not supported' }, 404);
       }
 
+      c.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+      c.header('Pragma', 'no-cache');
+      c.header('Expires', '0');
       return c.json(result);
     } catch (error) {
       console.error(`Error in ${resource} endpoint:`, error);
@@ -236,6 +245,9 @@ app.get('/:resource/:type/:id\\.json', async c => {
         return c.json({ error: 'Resource not supported' }, 404);
       }
 
+      c.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+      c.header('Pragma', 'no-cache');
+      c.header('Expires', '0');
       return c.json(result);
     } catch (error) {
       console.error(`Error in ${resource} endpoint:`, error);

--- a/packages/cloudflare/routes/configPage.ts
+++ b/packages/cloudflare/routes/configPage.ts
@@ -70,7 +70,11 @@ export const addCatalog = async (c: any) => {
     catalogUrl,
     url => catalogAggregator.fetchCatalogManifest(url),
     (userId, manifest) => configManager.addCatalog(userId, manifest),
-    userId => clearAddonCache(userId)
+    userId => {
+      // Clear both caches to ensure fresh data
+      clearAddonCache(userId);
+      configManager.clearUserCache(userId);
+    }
   );
 
   if (result.success) {
@@ -96,7 +100,11 @@ export const removeCatalog = async (c: any) => {
     userId,
     catalogId,
     (userId, catalogId) => configManager.removeCatalog(userId, catalogId),
-    userId => clearAddonCache(userId)
+    userId => {
+      // Clear both caches to ensure fresh data
+      clearAddonCache(userId);
+      configManager.clearUserCache(userId);
+    }
   );
 
   if (result.success) {
@@ -122,7 +130,11 @@ export const moveCatalogUp = async (c: any) => {
     userId,
     catalogId,
     (userId, catalogId) => configManager.moveCatalogUp(userId, catalogId),
-    userId => clearAddonCache(userId)
+    userId => {
+      // Clear both caches to ensure fresh data
+      clearAddonCache(userId);
+      configManager.clearUserCache(userId);
+    }
   );
 
   if (result.success) {
@@ -148,7 +160,11 @@ export const moveCatalogDown = async (c: any) => {
     userId,
     catalogId,
     (userId, catalogId) => configManager.moveCatalogDown(userId, catalogId),
-    userId => clearAddonCache(userId)
+    userId => {
+      // Clear both caches to ensure fresh data
+      clearAddonCache(userId);
+      configManager.clearUserCache(userId);
+    }
   );
 
   if (result.success) {

--- a/packages/types/common.ts
+++ b/packages/types/common.ts
@@ -25,6 +25,7 @@ export interface CatalogManifest {
 export interface UserConfig {
   catalogs: CatalogManifest[];
   catalogOrder?: string[]; // Array of catalog IDs in the desired order
+  _cachedAt?: number; // Timestamp when the config was cached
 }
 
 export interface MetaPreviewItem {


### PR DESCRIPTION
- Added cache invalidation time to refresh cached configurations after 30 seconds.
- Introduced a method to explicitly clear user cache.
- Updated manifest routes to include cache control headers for better data freshness.
- Modified catalog management functions to clear both addon and user caches upon updates.