### PR TITLE
feat: implement catalog randomization feature with toggle functionality

### DIFF
--- a/packages/core/utils/manifestBuilder.ts
+++ b/packages/core/utils/manifestBuilder.ts
@@ -147,11 +147,13 @@ export function buildManifest(
  *
  * @param args Catalog request parameters
  * @param userCatalogs List of catalog sources for the user
+ * @param randomizedCatalogs List of catalog IDs to randomize
  * @returns Catalog response
  */
 export async function handleCatalogRequest(
   args: any,
-  userCatalogs: CatalogManifest[]
+  userCatalogs: CatalogManifest[],
+  randomizedCatalogs: string[] = []
 ): Promise<any> {
   logger.info(`Handling catalog request with args:`, args);
 
@@ -196,6 +198,19 @@ export async function handleCatalogRequest(
       metas.forEach((item: any) => {
         item.sourceAddon = sourceId;
       });
+
+      // Check if this catalog should be randomized
+      const shouldRandomize = randomizedCatalogs.includes(source.id);
+
+      if (shouldRandomize && metas.length > 1) {
+        logger.debug(`Randomizing catalog items for ${source.id}`);
+        // Fisher-Yates shuffle algorithm
+        for (let i = metas.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [metas[i], metas[j]] = [metas[j], metas[i]];
+        }
+        logger.debug(`Randomized ${metas.length} items for catalog ${source.id}`);
+      }
     }
 
     return { metas };

--- a/packages/platforms/cloudflare/index.ts
+++ b/packages/platforms/cloudflare/index.ts
@@ -136,6 +136,7 @@ import {
   removeCatalog,
   moveCatalogUp,
   moveCatalogDown,
+  toggleCatalogRandomize,
 } from '../../api/routes/configPage';
 
 // Import MDBList routes
@@ -170,6 +171,11 @@ app.post('/configure/:userId/moveUp', async c => {
 app.post('/configure/:userId/moveDown', async c => {
   initConfigManager(c);
   return moveCatalogDown(c);
+});
+
+app.post('/configure/:userId/toggleRandomize', async c => {
+  initConfigManager(c);
+  return toggleCatalogRandomize(c);
 });
 
 // MDBList endpoints

--- a/packages/types/common.ts
+++ b/packages/types/common.ts
@@ -26,6 +26,7 @@ export interface CatalogManifest {
 export interface UserConfig {
   catalogs: CatalogManifest[];
   catalogOrder?: string[]; // Array of catalog IDs in the desired order
+  randomizedCatalogs?: string[]; // Array of catalog IDs that should have randomized items
   _cachedAt?: number; // Timestamp when the config was cached
 }
 

--- a/templates/catalogListComponent.ts
+++ b/templates/catalogListComponent.ts
@@ -12,6 +12,7 @@ export function getCatalogListHTML(userId: string, catalogs: any[]): string {
       const isFirst = index === 0;
       const isLast = index === array.length - 1;
       const isOnly = array.length === 1;
+      const isRandomized = catalog.randomize === true;
 
       return `
     <div class="catalog-item flex items-start gap-3 group" data-draggable="true" data-catalog-id="${catalog.id}" data-catalog-index="${index}">
@@ -51,6 +52,13 @@ export function getCatalogListHTML(userId: string, catalogs: any[]): string {
             `
                 : ''
             }
+            <form method="POST" action="/configure/${userId}/toggleRandomize" class="flex-shrink-0">
+              <input type="hidden" name="catalogId" value="${catalog.id}">
+              <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ${isRandomized ? 'bg-primary text-primary-foreground hover:bg-primary/90' : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'} h-9 px-3 py-2">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-1"><path d="M2 18h1.4c1.3 0 2.5-.6 3.3-1.7l6.1-8.6c.7-1.1 2-1.7 3.3-1.7H22"></path><path d="m18 2 4 4-4 4"></path><path d="M2 6h1.9c1.5 0 2.9.9 3.6 2.2"></path><path d="M22 18h-5.9c-1.3 0-2.6-.7-3.3-1.8l-.5-.8"></path><path d="m18 14 4 4-4 4"></path></svg>
+                ${isRandomized ? 'Randomized' : 'Randomize'}
+              </button>
+            </form>
             <form method="POST" action="/configure/${userId}/remove" class="flex-shrink-0">
               <input type="hidden" name="catalogId" value="${catalog.id}">
               <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-destructive text-destructive-foreground hover:bg-destructive/90 h-9 px-3 py-2">


### PR DESCRIPTION
- Added `handleToggleRandomize` function to manage randomization state for catalogs.
- Introduced `toggleCatalogRandomize` route to handle user requests for toggling randomization.
- Updated `BaseConfigManager` to manage `randomizedCatalogs` and toggle randomization for specific catalogs.
- Enhanced `handleCatalogRequest` to support randomization of catalog items.
- Updated UI to include a button for toggling randomization for each catalog.

resolves #38 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to toggle randomization of catalog items, allowing catalogs to display items in a random order.
  - Introduced a new button in the catalog management interface to enable or disable randomization for each catalog.
- **Bug Fixes**
  - Catalog removal now also clears its randomization state, ensuring consistent behavior.
- **Chores**
  - Added a new API endpoint to support toggling catalog randomization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->