### PR TITLE
feat: add catalog renaming functionality

### DIFF
--- a/packages/api/routes/configPage.ts
+++ b/packages/api/routes/configPage.ts
@@ -187,6 +187,44 @@ export async function handleToggleRandomize(
   }
 }
 
+// Handler for renaming catalogs
+export async function handleRenameCatalog(
+  userId: string,
+  catalogId: string,
+  newName: string,
+  renameCatalog: (userId: string, catalogId: string, newName: string) => Promise<boolean>,
+  clearCache: (userId: string) => void
+) {
+  if (!catalogId) {
+    return { success: false, error: 'No catalog ID provided' };
+  }
+
+  if (!newName && newName.trim() === '') {
+    return { success: false, error: 'No new name provided' };
+  }
+
+  try {
+    const success = await renameCatalog(userId, catalogId, newName);
+    if (!success) {
+      return { success: false, error: 'Failed to rename catalog' };
+    }
+
+    // Clear caches
+    clearCache(userId);
+
+    return {
+      success: true,
+      message: 'Successfully renamed catalog',
+    };
+  } catch (error) {
+    console.error('Error renaming catalog:', error);
+    return {
+      success: false,
+      error: `Failed to rename catalog: ${error}`,
+    };
+  }
+}
+
 // Display configuration page
 export const getConfigPage = async (c: any) => {
   const userId = c.req.param('userId');
@@ -376,6 +414,38 @@ export const toggleCatalogRandomize = async (c: any) => {
       // Clear both caches to ensure fresh data
       clearAddonCache(userId);
       configManager.clearCache(userId);
+    }
+  );
+
+  if (result.success) {
+    return c.redirect(`/configure/${userId}?message=${result.message}`);
+  } else {
+    return c.redirect(`/configure/${userId}?error=${result.error}`);
+  }
+};
+
+// Add catalog rename handler function
+export const renameCatalog = async (c: any) => {
+  const userId = c.req.param('userId');
+  const formData = await c.req.formData();
+  const catalogId = formData.get('catalogId') as string;
+  const newName = formData.get('newName') as string;
+
+  // Check if user exists
+  const exists = await configManager.userExists(userId);
+  if (!exists) {
+    return c.redirect(`/configure?error=User with ID ${userId} not found`);
+  }
+
+  // Handle the rename
+  const result = await handleRenameCatalog(
+    userId,
+    catalogId,
+    newName,
+    configManager.renameCatalog.bind(configManager),
+    () => {
+      configManager.clearCache(userId);
+      clearAddonCache(userId);
     }
   );
 

--- a/packages/api/routes/configPage.ts
+++ b/packages/api/routes/configPage.ts
@@ -199,7 +199,7 @@ export async function handleRenameCatalog(
     return { success: false, error: 'No catalog ID provided' };
   }
 
-  if (!newName && newName.trim() === '') {
+  if (!newName || newName.trim() === '') {
     return { success: false, error: 'No new name provided' };
   }
 

--- a/packages/core/config/configManager.ts
+++ b/packages/core/config/configManager.ts
@@ -253,6 +253,28 @@ export abstract class BaseConfigManager {
   }
 
   /**
+   * Rename a catalog in the user's configuration
+   */
+  async renameCatalog(userId: string, id: string, newName: string): Promise<boolean> {
+    logger.debug(`Renaming catalog ${id} for user ${userId} to ${newName}`);
+    const config = await this.loadConfig(userId);
+
+    // Find the catalog with the matching ID
+    const catalog = config.catalogs.find((c: CatalogManifest) => c.id === id);
+
+    if (!catalog) {
+      logger.debug(`Catalog ${id} not found for user ${userId}`);
+      return false;
+    }
+
+    // Update the customName field
+    catalog.customName = newName.trim() || undefined;
+
+    logger.debug(`Updated catalog ${id} with custom name: ${catalog.customName}`);
+    return await this.saveConfig(userId, config);
+  }
+
+  /**
    * Get a specific catalog for a user
    */
   async getCatalog(userId: string, id: string): Promise<CatalogManifest | undefined> {

--- a/packages/core/utils/manifestBuilder.ts
+++ b/packages/core/utils/manifestBuilder.ts
@@ -85,6 +85,8 @@ export function buildManifest(
                 ...catalog,
                 id: prefixedId,
                 source: source.id,
+                // Use customName if available, otherwise use original catalog name
+                name: source.customName || catalog.name,
               });
               catalogIds.add(prefixedId);
             }

--- a/packages/types/common.ts
+++ b/packages/types/common.ts
@@ -21,6 +21,7 @@ export interface CatalogManifest {
   };
   endpoint: string;
   context?: any; // Additional context information (like apiKey)
+  customName?: string; // Custom name for the catalog defined by the user
 }
 
 export interface UserConfig {

--- a/templates/catalogListComponent.ts
+++ b/templates/catalogListComponent.ts
@@ -13,6 +13,8 @@ export function getCatalogListHTML(userId: string, catalogs: any[]): string {
       const isLast = index === array.length - 1;
       const isOnly = array.length === 1;
       const isRandomized = catalog.randomize === true;
+      const displayName = catalog.customName || catalog.name;
+      const isCustomNamed = !!catalog.customName;
 
       return `
     <div class="catalog-item flex items-start gap-3 group" data-draggable="true" data-catalog-id="${catalog.id}" data-catalog-index="${index}">
@@ -23,7 +25,10 @@ export function getCatalogListHTML(userId: string, catalogs: any[]): string {
         <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div class="flex-grow overflow-hidden min-w-0">
             <div class="flex flex-wrap items-center gap-2">
-              <h3 class="font-medium text-lg truncate max-w-full">${catalog.name}</h3>
+              <h3 class="font-medium text-lg truncate max-w-full">
+                ${displayName}
+                ${isCustomNamed ? `<span class="text-xs text-muted-foreground">(Original: ${catalog.name})</span>` : ''}
+              </h3>
             </div>
             <p class="text-sm text-muted-foreground">${catalog.description}</p>
             </div>
@@ -52,6 +57,10 @@ export function getCatalogListHTML(userId: string, catalogs: any[]): string {
             `
                 : ''
             }
+            <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-secondary text-secondary-foreground hover:bg-secondary/80 h-9 px-3 py-2" onclick="toggleRenameForm('${catalog.id}')">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="mr-1"><path d="M17 3a2.85 2.85 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path></svg>
+              Rename
+            </button>
             <form method="POST" action="/configure/${userId}/toggleRandomize" class="flex-shrink-0">
               <input type="hidden" name="catalogId" value="${catalog.id}">
               <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ${isRandomized ? 'bg-primary text-primary-foreground hover:bg-primary/90' : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'} h-9 px-3 py-2">
@@ -67,6 +76,27 @@ export function getCatalogListHTML(userId: string, catalogs: any[]): string {
               </button>
             </form>
           </div>
+        </div>
+        <div id="rename-form-${catalog.id}" class="rename-form hidden mt-2 p-3 border border-border rounded-md bg-muted/30">
+          <form method="POST" action="/configure/${userId}/rename" class="flex items-center gap-2">
+            <input type="hidden" name="catalogId" value="${catalog.id}">
+            <div class="flex-grow">
+              <input
+                type="text"
+                name="newName"
+                value="${catalog.customName || catalog.name}"
+                placeholder="Enter new name"
+                class="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                required
+              />
+            </div>
+            <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-9 px-3 py-2">
+              Save
+            </button>
+            <button type="button" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-secondary text-secondary-foreground hover:bg-secondary/80 h-9 px-3 py-2" onclick="toggleRenameForm('${catalog.id}')">
+              Cancel
+            </button>
+          </form>
         </div>
       </div>
     </div>

--- a/templates/pageScriptsComponent.ts
+++ b/templates/pageScriptsComponent.ts
@@ -178,6 +178,74 @@ export function getPageScriptsHTML(message: string = '', error: string = ''): st
         item.setAttribute('data-catalog-index', index.toString());
       });
     }
+
+    // Function to show a flash message
+    function showMessage(type, message) {
+      // Remove any existing messages
+      const existingMessages = document.querySelectorAll('.flash-message');
+      existingMessages.forEach(element => {
+        element.remove();
+      });
+      
+      // Create the message element
+      const messageElement = document.createElement('div');
+      messageElement.className = \`flash-message flash-\${type} fixed top-4 right-4 p-4 rounded-lg shadow-lg max-w-md z-50\`;
+      messageElement.innerHTML = \`
+        <div class="flex items-center gap-3">
+          <div class="flex-shrink-0">
+            \${type === 'success' ? \`
+              <svg class="w-5 h-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
+              </svg>
+            \` : type === 'error' ? \`
+              <svg class="w-5 h-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
+              </svg>
+            \` : \`
+              <svg class="w-5 h-5 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path>
+              </svg>
+            \`}
+          </div>
+          <div>
+            <p class="text-sm font-medium text-gray-900">\${message}</p>
+          </div>
+          <div class="flex-shrink-0 ml-auto">
+            <button type="button" onclick="this.parentElement.parentElement.remove()" class="inline-flex text-gray-400 hover:text-gray-500">
+              <span class="sr-only">Close</span>
+              <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+      \`;
+      
+      // Add the message to the page
+      document.body.appendChild(messageElement);
+      
+      // Remove after a delay
+      setTimeout(() => {
+        messageElement.remove();
+      }, 5000);
+    }
+    
+    // Toggle rename form visibility
+    function toggleRenameForm(catalogId) {
+      const form = document.getElementById('rename-form-' + catalogId);
+      if (form) {
+        form.classList.toggle('hidden');
+        
+        // If form is now visible, focus on the input field
+        if (!form.classList.contains('hidden')) {
+          const input = form.querySelector('input[name="newName"]');
+          if (input) {
+            input.focus();
+            input.select();
+          }
+        }
+      }
+    }
   </script>
   `;
 }


### PR DESCRIPTION
resolves #42 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to rename catalogs through the interface, including a new "Rename" button and form for each catalog.
  - Custom catalog names are now displayed throughout the app and reflected in manifest files and descriptions.
- **User Interface**
  - Enhanced catalog list with rename controls and improved display of custom and original catalog names.
  - Added flash messages for feedback on actions such as renaming.
- **Improvements**
  - Catalog renaming is now supported via a new POST endpoint for seamless updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->