### PR TITLE
fix: initialize config manager in rename catalog endpoint

### DIFF
--- a/packages/platforms/cloudflare/index.ts
+++ b/packages/platforms/cloudflare/index.ts
@@ -180,6 +180,7 @@ app.post('/configure/:userId/toggleRandomize', async c => {
 });
 
 app.post('/configure/:userId/rename', async c => {
+  initConfigManager(c);
   return renameCatalog(c);
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency for configuration updates when renaming users via the `/configure/:userId/rename` route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->