### PR TITLE
feat: implement RPDB support for all catalog items posters

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1,2 +1,4 @@
 // API exports
 export * from './routes/configPage';
+export * from './routes/mdblistRoutes';
+export * from './routes/rpdbRoutes';

--- a/packages/api/routes/configPage.ts
+++ b/packages/api/routes/configPage.ts
@@ -257,7 +257,7 @@ export const getConfigPage = async (c: any) => {
     // Load the RPDB API key from the database to display in the form
     let rpdbApiKey = '';
     try {
-      rpdbApiKey = (await configManager.loadRPDBAApiKey(userId)) || '';
+      rpdbApiKey = (await configManager.loadRPDBApiKey(userId)) || '';
       console.log(`Loaded RPDB API key for user ${userId} for config page`);
     } catch (apiKeyError) {
       console.warn(`Error loading RPDB API key for user ${userId}:`, apiKeyError);

--- a/packages/api/routes/configPage.ts
+++ b/packages/api/routes/configPage.ts
@@ -245,12 +245,22 @@ export const getConfigPage = async (c: any) => {
     const catalogs = await configManager.getAllCatalogs(userId);
 
     // Load the MDBList API key from the database to display in the form
-    let apiKey = '';
+    let mdblistApiKey = '';
     try {
-      apiKey = (await configManager.loadMDBListApiKey(userId)) || '';
+      mdblistApiKey = (await configManager.loadMDBListApiKey(userId)) || '';
       console.log(`Loaded MDBList API key for user ${userId} for config page`);
     } catch (apiKeyError) {
       console.warn(`Error loading MDBList API key for user ${userId}:`, apiKeyError);
+      // Ignore errors here as it's not critical
+    }
+
+    // Load the RPDB API key from the database to display in the form
+    let rpdbApiKey = '';
+    try {
+      rpdbApiKey = (await configManager.loadRPDBAApiKey(userId)) || '';
+      console.log(`Loaded RPDB API key for user ${userId} for config page`);
+    } catch (apiKeyError) {
+      console.warn(`Error loading RPDB API key for user ${userId}:`, apiKeyError);
       // Ignore errors here as it's not critical
     }
 
@@ -262,7 +272,17 @@ export const getConfigPage = async (c: any) => {
 
     // Return HTML as text
     return c.html(
-      getConfigPageHTML(userId, catalogs, baseUrl, message, error, true, PACKAGE_VERSION, apiKey)
+      getConfigPageHTML(
+        userId,
+        catalogs,
+        baseUrl,
+        message,
+        error,
+        true,
+        PACKAGE_VERSION,
+        mdblistApiKey,
+        rpdbApiKey
+      )
     );
   } catch (error) {
     console.error('Error displaying config page:', error);

--- a/packages/api/routes/rpdbRoutes.ts
+++ b/packages/api/routes/rpdbRoutes.ts
@@ -4,7 +4,7 @@ import { logger } from '../../core/utils/logger';
 // Helper function to load RPDB API key for a user
 export async function loadUserRPDBApiKey(userId: string): Promise<string | null> {
   try {
-    return await configManager.loadRPDBAApiKey(userId);
+    return await configManager.loadRPDBApiKey(userId);
   } catch (error) {
     logger.error('Error loading RPDB API key:', error);
     return null;
@@ -66,7 +66,7 @@ export const saveRPDBConfig = async (c: any) => {
     }
 
     // Save the API key to the database
-    const success = await configManager.saveRPDBAApiKey(userId, apiKey);
+    const success = await configManager.saveRPDBApiKey(userId, apiKey);
 
     if (!success) {
       logger.warn(`Database save failed for RPDB API key for user ${userId}`);

--- a/packages/api/routes/rpdbRoutes.ts
+++ b/packages/api/routes/rpdbRoutes.ts
@@ -1,17 +1,12 @@
 import { configManager } from '../../platforms/cloudflare/configManager';
 import { logger } from '../../core/utils/logger';
 
-// Helper function to load the RPDB API key for a user
+// Helper function to load RPDB API key for a user
 export async function loadUserRPDBApiKey(userId: string): Promise<string | null> {
   try {
-    const apiKey = await configManager.loadRPDBAApiKey(userId);
-    if (apiKey) {
-      logger.debug(`Loaded RPDB API key for user ${userId}`);
-      return apiKey;
-    }
-    return null;
+    return await configManager.loadRPDBAApiKey(userId);
   } catch (error) {
-    logger.error(`Error loading RPDB API key for user ${userId}:`, error);
+    logger.error('Error loading RPDB API key:', error);
     return null;
   }
 }

--- a/packages/api/routes/rpdbRoutes.ts
+++ b/packages/api/routes/rpdbRoutes.ts
@@ -1,0 +1,92 @@
+import { configManager } from '../../platforms/cloudflare/configManager';
+import { logger } from '../../core/utils/logger';
+
+// Helper function to load the RPDB API key for a user
+export async function loadUserRPDBApiKey(userId: string): Promise<string | null> {
+  try {
+    const apiKey = await configManager.loadRPDBAApiKey(userId);
+    if (apiKey) {
+      logger.debug(`Loaded RPDB API key for user ${userId}`);
+      return apiKey;
+    }
+    return null;
+  } catch (error) {
+    logger.error(`Error loading RPDB API key for user ${userId}:`, error);
+    return null;
+  }
+}
+
+// Helper function to validate an RPDB API key
+async function validateRPDBApiKey(apiKey: string): Promise<boolean> {
+  try {
+    // Validation to the RPDB API
+    const testUrl = `https://api.ratingposterdb.com/${apiKey}/isValid`;
+
+    const response = await fetch(testUrl);
+    if (response.ok && response.status === 200) {
+      return true;
+    }
+
+    logger.warn(`RPDB API key validation failed: ${response.status} ${response.statusText}`);
+    return false;
+  } catch (error) {
+    logger.error('Error validating RPDB API key:', error);
+    return false;
+  }
+}
+
+// Save RPDB API configuration
+export const saveRPDBConfig = async (c: any) => {
+  const userId = c.req.param('userId');
+  const formData = await c.req.formData();
+  const apiKey = formData.get('apiKey') as string;
+
+  // Check if user exists
+  const exists = await configManager.userExists(userId);
+  if (!exists) {
+    return c.redirect('/configure?error=User not found');
+  }
+
+  try {
+    // Check if the API key is valid before saving it
+    if (!apiKey || apiKey.trim() === '') {
+      return c.redirect(`/configure/${userId}?error=RPDB API key cannot be empty`);
+    }
+
+    // Validate the API key by making a test call to the RPDB API
+    try {
+      const isValid = await validateRPDBApiKey(apiKey);
+      if (!isValid) {
+        logger.warn(`RPDB API key validation failed for user ${userId}`);
+        return c.redirect(
+          `/configure/${userId}?error=Invalid RPDB API key - please check and try again`
+        );
+      }
+      logger.info(`Successfully validated RPDB API key for user ${userId}`);
+    } catch (validationError) {
+      logger.error(`RPDB API key validation failed for user ${userId}:`, validationError);
+      return c.redirect(
+        `/configure/${userId}?error=Invalid RPDB API key - please check and try again`
+      );
+    }
+
+    // Save the API key to the database
+    const success = await configManager.saveRPDBAApiKey(userId, apiKey);
+
+    if (!success) {
+      logger.warn(`Database save failed for RPDB API key for user ${userId}`);
+      // Inform the user that there was a problem
+      return c.redirect(
+        `/configure/${userId}?error=Could not save RPDB API key permanently. Please try again.`
+      );
+    }
+
+    // Clear the API key cache to ensure the new key is used immediately
+    configManager.clearApiKeyCache(userId);
+
+    return c.redirect(`/configure/${userId}?message=RPDB API configuration saved successfully`);
+  } catch (error) {
+    logger.error(`Error saving RPDB API key for user ${userId}:`, error);
+    return c.redirect(`/configure/${userId}?error=Failed to save RPDB API key. Please try again.`);
+  }
+};

--- a/packages/api/tests/rpdbRoutes.test.ts
+++ b/packages/api/tests/rpdbRoutes.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { loadUserRPDBApiKey, saveRPDBConfig } from '../routes/rpdbRoutes';
+import { configManager } from '../../platforms/cloudflare/configManager';
+
+// Mock the configManager
+vi.mock('../../platforms/cloudflare/configManager', () => ({
+  configManager: {
+    loadRPDBAApiKey: vi.fn(),
+    saveRPDBAApiKey: vi.fn(),
+    userExists: vi.fn(),
+    clearApiKeyCache: vi.fn(),
+  },
+}));
+
+// Mock the logger
+vi.mock('../../core/utils/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock fetch for validating API key
+global.fetch = vi.fn();
+
+describe('RPDB API Routes', () => {
+  // Reset all mocks before each test
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('loadUserRPDBApiKey', () => {
+    it('should return API key when successfully loaded', async () => {
+      const mockApiKey = 'test-api-key-123';
+      vi.mocked(configManager.loadRPDBAApiKey).mockResolvedValue(mockApiKey);
+
+      const result = await loadUserRPDBApiKey('user123');
+      expect(result).toBe(mockApiKey);
+      expect(configManager.loadRPDBAApiKey).toHaveBeenCalledWith('user123');
+    });
+
+    it('should return null when error occurs', async () => {
+      vi.mocked(configManager.loadRPDBAApiKey).mockRejectedValue(new Error('Database error'));
+
+      const result = await loadUserRPDBApiKey('user123');
+      expect(result).toBeNull();
+      expect(configManager.loadRPDBAApiKey).toHaveBeenCalledWith('user123');
+    });
+  });
+
+  describe('saveRPDBConfig', () => {
+    // Mock context object for Hono
+    const mockContext = (userId: string, apiKey: string, formData = new FormData()) => {
+      formData.append('apiKey', apiKey);
+
+      return {
+        req: {
+          param: vi.fn().mockReturnValue(userId),
+          formData: vi.fn().mockResolvedValue(formData),
+        },
+        redirect: vi.fn().mockImplementation(url => ({ redirectUrl: url })),
+      };
+    };
+
+    it('should redirect with error when user does not exist', async () => {
+      const ctx = mockContext('nonexistent-user', 'api-key');
+      vi.mocked(configManager.userExists).mockResolvedValue(false);
+
+      const result = await saveRPDBConfig(ctx);
+      expect(result).toEqual({ redirectUrl: '/configure?error=User not found' });
+      expect(configManager.userExists).toHaveBeenCalledWith('nonexistent-user');
+    });
+
+    it('should redirect with error when API key is empty', async () => {
+      const userId = 'user123';
+      const ctx = mockContext(userId, '');
+      vi.mocked(configManager.userExists).mockResolvedValue(true);
+
+      const result = await saveRPDBConfig(ctx);
+      expect(result).toEqual({
+        redirectUrl: `/configure/${userId}?error=RPDB API key cannot be empty`,
+      });
+    });
+
+    it('should validate API key and save when valid', async () => {
+      const userId = 'user123';
+      const apiKey = 'valid-api-key';
+      const ctx = mockContext(userId, apiKey);
+
+      vi.mocked(configManager.userExists).mockResolvedValue(true);
+
+      // Create a spy for the internal validateRPDBApiKey call
+      const validateSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+      } as Response);
+
+      vi.mocked(configManager.saveRPDBAApiKey).mockResolvedValue(true);
+
+      const result = await saveRPDBConfig(ctx);
+
+      // Verify that fetch was called with the expected URL
+      expect(validateSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`https://api.ratingposterdb.com/${apiKey}/isValid`)
+      );
+      expect(configManager.saveRPDBAApiKey).toHaveBeenCalledWith(userId, apiKey);
+      expect(configManager.clearApiKeyCache).toHaveBeenCalledWith(userId);
+      expect(result).toEqual({
+        redirectUrl: `/configure/${userId}?message=RPDB API configuration saved successfully`,
+      });
+    });
+
+    it('should redirect with error when API key validation fails', async () => {
+      const userId = 'user123';
+      const apiKey = 'invalid-api-key';
+      const ctx = mockContext(userId, apiKey);
+
+      vi.mocked(configManager.userExists).mockResolvedValue(true);
+
+      // Mock fetch to simulate API key validation failure
+      vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      } as Response);
+
+      const result = await saveRPDBConfig(ctx);
+
+      expect(result).toEqual({
+        redirectUrl: `/configure/${userId}?error=Invalid RPDB API key - please check and try again`,
+      });
+    });
+
+    it('should redirect with error when database save fails', async () => {
+      const userId = 'user123';
+      const apiKey = 'valid-api-key';
+      const ctx = mockContext(userId, apiKey);
+
+      vi.mocked(configManager.userExists).mockResolvedValue(true);
+
+      // Mock successful validation
+      vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+      } as Response);
+
+      // But database save fails
+      vi.mocked(configManager.saveRPDBAApiKey).mockResolvedValue(false);
+
+      const result = await saveRPDBConfig(ctx);
+
+      expect(result).toEqual({
+        redirectUrl: `/configure/${userId}?error=Could not save RPDB API key permanently. Please try again.`,
+      });
+    });
+
+    it('should redirect with error when exception occurs', async () => {
+      const userId = 'user123';
+      const apiKey = 'valid-api-key';
+      const ctx = mockContext(userId, apiKey);
+
+      vi.mocked(configManager.userExists).mockResolvedValue(true);
+
+      // Mock successful validation
+      vi.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+      } as Response);
+
+      // But database operation throws error
+      vi.mocked(configManager.saveRPDBAApiKey).mockRejectedValue(new Error('Database error'));
+
+      const result = await saveRPDBConfig(ctx);
+
+      expect(result).toEqual({
+        redirectUrl: `/configure/${userId}?error=Failed to save RPDB API key. Please try again.`,
+      });
+    });
+  });
+});

--- a/packages/api/tests/rpdbRoutes.test.ts
+++ b/packages/api/tests/rpdbRoutes.test.ts
@@ -5,8 +5,8 @@ import { configManager } from '../../platforms/cloudflare/configManager';
 // Mock the configManager
 vi.mock('../../platforms/cloudflare/configManager', () => ({
   configManager: {
-    loadRPDBAApiKey: vi.fn(),
-    saveRPDBAApiKey: vi.fn(),
+    loadRPDBApiKey: vi.fn(),
+    saveRPDBApiKey: vi.fn(),
     userExists: vi.fn(),
     clearApiKeyCache: vi.fn(),
   },
@@ -38,19 +38,19 @@ describe('RPDB API Routes', () => {
   describe('loadUserRPDBApiKey', () => {
     it('should return API key when successfully loaded', async () => {
       const mockApiKey = 'test-api-key-123';
-      vi.mocked(configManager.loadRPDBAApiKey).mockResolvedValue(mockApiKey);
+      vi.mocked(configManager.loadRPDBApiKey).mockResolvedValue(mockApiKey);
 
       const result = await loadUserRPDBApiKey('user123');
       expect(result).toBe(mockApiKey);
-      expect(configManager.loadRPDBAApiKey).toHaveBeenCalledWith('user123');
+      expect(configManager.loadRPDBApiKey).toHaveBeenCalledWith('user123');
     });
 
     it('should return null when error occurs', async () => {
-      vi.mocked(configManager.loadRPDBAApiKey).mockRejectedValue(new Error('Database error'));
+      vi.mocked(configManager.loadRPDBApiKey).mockRejectedValue(new Error('Database error'));
 
       const result = await loadUserRPDBApiKey('user123');
       expect(result).toBeNull();
-      expect(configManager.loadRPDBAApiKey).toHaveBeenCalledWith('user123');
+      expect(configManager.loadRPDBApiKey).toHaveBeenCalledWith('user123');
     });
   });
 
@@ -101,7 +101,7 @@ describe('RPDB API Routes', () => {
         status: 200,
       } as Response);
 
-      vi.mocked(configManager.saveRPDBAApiKey).mockResolvedValue(true);
+      vi.mocked(configManager.saveRPDBApiKey).mockResolvedValue(true);
 
       const result = await saveRPDBConfig(ctx);
 
@@ -109,7 +109,7 @@ describe('RPDB API Routes', () => {
       expect(validateSpy).toHaveBeenCalledWith(
         expect.stringContaining(`https://api.ratingposterdb.com/${apiKey}/isValid`)
       );
-      expect(configManager.saveRPDBAApiKey).toHaveBeenCalledWith(userId, apiKey);
+      expect(configManager.saveRPDBApiKey).toHaveBeenCalledWith(userId, apiKey);
       expect(configManager.clearApiKeyCache).toHaveBeenCalledWith(userId);
       expect(result).toEqual({
         redirectUrl: `/configure/${userId}?message=RPDB API configuration saved successfully`,
@@ -151,7 +151,7 @@ describe('RPDB API Routes', () => {
       } as Response);
 
       // But database save fails
-      vi.mocked(configManager.saveRPDBAApiKey).mockResolvedValue(false);
+      vi.mocked(configManager.saveRPDBApiKey).mockResolvedValue(false);
 
       const result = await saveRPDBConfig(ctx);
 
@@ -174,7 +174,7 @@ describe('RPDB API Routes', () => {
       } as Response);
 
       // But database operation throws error
-      vi.mocked(configManager.saveRPDBAApiKey).mockRejectedValue(new Error('Database error'));
+      vi.mocked(configManager.saveRPDBApiKey).mockRejectedValue(new Error('Database error'));
 
       const result = await saveRPDBConfig(ctx);
 

--- a/packages/core/config/configManager.ts
+++ b/packages/core/config/configManager.ts
@@ -324,4 +324,14 @@ export abstract class BaseConfigManager {
    * Load MDBList API key for a user
    */
   abstract loadMDBListApiKey(userId: string): Promise<string | null> | string | null;
+
+  /**
+   * Save RPDB API key for a user
+   */
+  abstract saveRPDBAApiKey(userId: string, apiKey: string): Promise<boolean> | boolean;
+
+  /**
+   * Load RPDB API key for a user
+   */
+  abstract loadRPDBAApiKey(userId: string): Promise<string | null> | string | null;
 }

--- a/packages/core/config/configManager.ts
+++ b/packages/core/config/configManager.ts
@@ -328,10 +328,10 @@ export abstract class BaseConfigManager {
   /**
    * Save RPDB API key for a user
    */
-  abstract saveRPDBAApiKey(userId: string, apiKey: string): Promise<boolean> | boolean;
+  abstract saveRPDBApiKey(userId: string, apiKey: string): Promise<boolean> | boolean;
 
   /**
    * Load RPDB API key for a user
    */
-  abstract loadRPDBAApiKey(userId: string): Promise<string | null> | string | null;
+  abstract loadRPDBApiKey(userId: string): Promise<string | null> | string | null;
 }

--- a/packages/core/tests/configManager.test.ts
+++ b/packages/core/tests/configManager.test.ts
@@ -6,12 +6,14 @@ import { UserConfig, CatalogManifest } from '../../types/index';
 class MockConfigManager extends BaseConfigManager {
   private configs: Map<string, UserConfig>;
   private mdbApiKeys: Map<string, string>;
+  private rpdbApiKeys: Map<string, string>;
   private users: Set<string>;
 
   constructor() {
     super();
     this.configs = new Map();
     this.mdbApiKeys = new Map();
+    this.rpdbApiKeys = new Map();
     this.users = new Set(['test-user']);
 
     // Set up initial test data
@@ -66,6 +68,15 @@ class MockConfigManager extends BaseConfigManager {
 
   loadMDBListApiKey(userId: string): string | null {
     return this.mdbApiKeys.get(userId) || null;
+  }
+
+  saveRPDBAApiKey(userId: string, apiKey: string): boolean {
+    this.rpdbApiKeys.set(userId, apiKey);
+    return true;
+  }
+
+  loadRPDBAApiKey(userId: string): string | null {
+    return this.rpdbApiKeys.get(userId) || null;
   }
 
   // Test helpers to access protected properties

--- a/packages/core/tests/configManager.test.ts
+++ b/packages/core/tests/configManager.test.ts
@@ -70,12 +70,12 @@ class MockConfigManager extends BaseConfigManager {
     return this.mdbApiKeys.get(userId) || null;
   }
 
-  saveRPDBAApiKey(userId: string, apiKey: string): boolean {
+  saveRPDBApiKey(userId: string, apiKey: string): boolean {
     this.rpdbApiKeys.set(userId, apiKey);
     return true;
   }
 
-  loadRPDBAApiKey(userId: string): string | null {
+  loadRPDBApiKey(userId: string): string | null {
     return this.rpdbApiKeys.get(userId) || null;
   }
 

--- a/packages/core/tests/posterUtils.test.ts
+++ b/packages/core/tests/posterUtils.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getPosterUrl, processPosterUrls } from '../utils/posterUtils';
+import * as logger from '../utils/logger';
+
+// Mock the appConfig
+vi.mock('../../platforms/cloudflare/appConfig', () => ({
+  appConfig: {
+    api: {
+      cacheExpirationRPDB: 7,
+    },
+  },
+}));
+
+// Mock the logger
+vi.mock('../utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('Poster Utilities', () => {
+  const originalDate = global.Date.now;
+  const mockNow = 1625097600000; // Fixed timestamp for testing
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Mock Date.now for consistent cache testing
+    global.Date.now = vi.fn().mockReturnValue(mockNow);
+  });
+
+  afterEach(() => {
+    // Restore Date.now
+    global.Date.now = originalDate;
+  });
+
+  describe('getPosterUrl', () => {
+    it('should return original URL when no RPDB API key is provided', () => {
+      const originalUrl = 'https://example.com/poster.jpg';
+      const result = getPosterUrl(originalUrl, null, 'tt1234567');
+      expect(result).toBe(originalUrl);
+    });
+
+    it('should return empty string when original URL is undefined and no API key is provided', () => {
+      const result = getPosterUrl(undefined, null, 'tt1234567');
+      expect(result).toBe('');
+    });
+
+    it('should return RPDB URL when API key is provided', () => {
+      const originalUrl = 'https://example.com/poster.jpg';
+      const apiKey = 'test-api-key';
+      const mediaId = 'tt1234567';
+
+      const result = getPosterUrl(originalUrl, apiKey, mediaId);
+
+      const expectedUrl = `https://api.ratingposterdb.com/${apiKey}/imdb/poster-default/${mediaId}.jpg?fallback=true`;
+      expect(result).toBe(expectedUrl);
+    });
+
+    it('should use cached URL if available and not expired', () => {
+      const originalUrl = 'https://example.com/poster.jpg';
+      const apiKey = 'test-api-key';
+      const mediaId = 'tt1234567';
+
+      // First call to cache the URL
+      const result1 = getPosterUrl(originalUrl, apiKey, mediaId);
+
+      // Second call should use cached URL
+      const result2 = getPosterUrl(originalUrl, apiKey, mediaId);
+
+      expect(result1).toBe(result2);
+    });
+
+    it('should generate new URL when cache is expired', () => {
+      const originalUrl = 'https://example.com/poster.jpg';
+      const apiKey = 'test-api-key';
+      const mediaId = 'tt1234567';
+
+      // First call to cache the URL
+      const result1 = getPosterUrl(originalUrl, apiKey, mediaId);
+
+      // Reset the mock call count
+      vi.mocked(global.Date.now).mockClear();
+
+      // Advance time past cache expiration (7 days + 1 ms)
+      const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+      global.Date.now = vi.fn().mockReturnValue(mockNow + sevenDaysMs + 1);
+
+      // Second call should generate a new URL (but in this case it's the same)
+      const result2 = getPosterUrl(originalUrl, apiKey, mediaId);
+
+      // The URLs should be the same in content, but we've verified cache expiration by
+      // checking that Date.now was called a second time after our mock update
+      expect(result1).toBe(result2);
+      // Date.now should be called at least twice - once for checking expiration and once for setting new timestamp
+      expect(global.Date.now).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return original URL on error', () => {
+      const originalUrl = 'https://example.com/poster.jpg';
+      const apiKey = 'test-api-key';
+      const mediaId = 'tt1234567';
+
+      // Force an error by mocking Date.now to throw
+      const originalDateNow = global.Date.now;
+      global.Date.now = vi.fn().mockImplementation(() => {
+        throw new Error('Test error');
+      });
+
+      try {
+        const result = getPosterUrl(originalUrl, apiKey, mediaId);
+
+        // Should return the original URL on error
+        expect(result).toBe(originalUrl);
+
+        // Verify that an error was logged
+        expect(logger.logger.error).toHaveBeenCalled();
+      } finally {
+        // Always restore the original method
+        global.Date.now = originalDateNow;
+      }
+    });
+  });
+
+  describe('processPosterUrls', () => {
+    it('should not modify metas when no RPDB API key is provided', () => {
+      const metas = [
+        { id: 'tt1234567', poster: 'https://example.com/poster1.jpg' },
+        { id: 'tt7654321', poster: 'https://example.com/poster2.jpg' },
+      ];
+
+      const result = processPosterUrls(metas, null);
+
+      expect(result).toEqual(metas);
+      // Verify the original objects haven't been modified
+      expect(result).toBe(metas);
+    });
+
+    it('should replace poster URLs with RPDB URLs when API key is provided', () => {
+      const apiKey = 'test-api-key';
+      const metas = [
+        { id: 'tt1234567', poster: 'https://example.com/poster1.jpg' },
+        { id: 'tt7654321', poster: 'https://example.com/poster2.jpg' },
+      ];
+
+      const result = processPosterUrls(metas, apiKey);
+
+      // Expect poster URLs to be replaced with RPDB URLs
+      expect(result).toEqual([
+        {
+          id: 'tt1234567',
+          poster: `https://api.ratingposterdb.com/${apiKey}/imdb/poster-default/tt1234567.jpg?fallback=true`,
+        },
+        {
+          id: 'tt7654321',
+          poster: `https://api.ratingposterdb.com/${apiKey}/imdb/poster-default/tt7654321.jpg?fallback=true`,
+        },
+      ]);
+    });
+
+    it('should not modify meta items without poster or id', () => {
+      const apiKey = 'test-api-key';
+      const metas = [
+        { id: 'tt1234567', title: 'Test Movie' }, // No poster
+        { poster: 'https://example.com/poster.jpg', title: 'Another Movie' }, // No id
+        { id: 'tt7654321', poster: 'https://example.com/poster2.jpg', title: 'Complete Movie' }, // Both id and poster
+      ];
+
+      const result = processPosterUrls(metas, apiKey);
+
+      expect(result).toEqual([
+        { id: 'tt1234567', title: 'Test Movie' }, // Unchanged
+        { poster: 'https://example.com/poster.jpg', title: 'Another Movie' }, // Unchanged
+        {
+          id: 'tt7654321',
+          poster: `https://api.ratingposterdb.com/${apiKey}/imdb/poster-default/tt7654321.jpg?fallback=true`,
+          title: 'Complete Movie',
+        }, // Poster URL modified
+      ]);
+    });
+  });
+});

--- a/packages/core/utils/logger.ts
+++ b/packages/core/utils/logger.ts
@@ -316,6 +316,6 @@ export function initLogger(appConfig?: any): void {
     `Logger initialized with level: ${LogLevel[logger.getLevel()]}, Timestamps: ${timestampStatus}, Format: ${logger.getTimestampFormat()}, Timezone: ${logger.getTimezone()}`
   );
   logger.debug(
-    `AIOCatalogs Settings: AIOCATALOGS_API_MAX_ITEMS_MDBLIST: ${appConfig.api.maxItemsMDBList}, AIOCATALOGS_API_MAX_REQUESTS: ${appConfig.api.maxRequestsPerMinute}, AIOCATALOGS_API_RATE_LIMIT: ${appConfig.api.rateLimit}, AIOCATALOGS_TRUSTED_ORIGINS: ${appConfig.app.trustedOrigins}`
+    `AIOCatalogs Settings: AIOCATALOGS_API_MAX_ITEMS_MDBLIST: ${appConfig.api.maxItemsMDBList}, AIOCATALOGS_API_MAX_REQUESTS: ${appConfig.api.maxRequestsPerMinute}, AIOCATALOGS_API_RATE_LIMIT: ${appConfig.api.rateLimit}, AIOCATALOGS_TRUSTED_ORIGINS: ${appConfig.app.trustedOrigins}, AIOCATALOGS_API_CACHE_EXPIRATION_RPDB: ${appConfig.api.cacheExpirationRPDB}`
   );
 }

--- a/packages/core/utils/posterUtils.ts
+++ b/packages/core/utils/posterUtils.ts
@@ -37,11 +37,8 @@ export function getPosterUrl(
       return cachedItem.url;
     }
 
-    // Extract the IMDb ID from the media ID (removing any prefixes like 'tt' for IMDb)
-    let cleanMediaId = mediaId;
-
     // Construct the RPDB URL
-    const rpdbUrl = `https://api.ratingposterdb.com/${rpdbApiKey}/imdb/poster-default/${cleanMediaId}.jpg?fallback=true`;
+    const rpdbUrl = `https://api.ratingposterdb.com/${rpdbApiKey}/imdb/poster-default/${mediaId}.jpg?fallback=true`;
 
     logger.debug(`Replacing poster URL: ${originalUrl} with RPDB URL: ${rpdbUrl}`);
 

--- a/packages/core/utils/posterUtils.ts
+++ b/packages/core/utils/posterUtils.ts
@@ -1,0 +1,56 @@
+import { logger } from './logger';
+
+/**
+ * Returns the appropriate poster URL - either using RPDB or the original URL
+ *
+ * @param originalUrl The original poster URL
+ * @param rpdbApiKey The user's RPDB API key (if any)
+ * @param mediaId The media ID (usually IMDb ID)
+ * @returns The URL to use for the poster
+ */
+export function getPosterUrl(
+  originalUrl: string | undefined,
+  rpdbApiKey: string | null,
+  mediaId: string
+): string {
+  // If no RPDB API key or no original URL, return the original URL
+  if (!rpdbApiKey || !originalUrl) {
+    return originalUrl || '';
+  }
+
+  try {
+    // Extract the IMDb ID from the media ID (removing any prefixes like 'tt' for IMDb)
+    let cleanMediaId = mediaId;
+
+    // Construct the RPDB URL
+    const rpdbUrl = `https://api.ratingposterdb.com/${rpdbApiKey}/imdb/poster-default/${cleanMediaId}.jpg?fallback=true`;
+
+    logger.debug(`Replacing poster URL: ${originalUrl} with RPDB URL: ${rpdbUrl}`);
+
+    return rpdbUrl;
+  } catch (error) {
+    // In case of any errors, fall back to the original URL
+    logger.error(`Error constructing RPDB poster URL for ${mediaId}:`, error);
+    return originalUrl;
+  }
+}
+
+/**
+ * Process meta items to replace poster URLs with RPDB URLs when applicable
+ *
+ * @param metas Array of meta items with poster URLs
+ * @param rpdbApiKey The user's RPDB API key (if any)
+ * @returns The same array with processed poster URLs
+ */
+export function processPosterUrls(metas: any[], rpdbApiKey: string | null): any[] {
+  if (!rpdbApiKey) {
+    return metas;
+  }
+
+  return metas.map(meta => {
+    if (meta.poster && meta.id) {
+      meta.poster = getPosterUrl(meta.poster, rpdbApiKey, meta.id);
+    }
+    return meta;
+  });
+}

--- a/packages/platforms/cloudflare/addon.ts
+++ b/packages/platforms/cloudflare/addon.ts
@@ -80,7 +80,7 @@ async function processMDBListCatalog(args: any, userId: string): Promise<{ metas
 
     // Process posters if RPDB API key is available
     if (rpdbApiKey && result.metas) {
-      result.metas = processPosterUrls(result.metas, rpdbApiKey);
+      result.metas = processPosterUrls([...result.metas], rpdbApiKey);
     }
 
     return result;
@@ -164,7 +164,7 @@ export async function getAddonInterface(userId: string, db: D1Database) {
 
       // Process posters if RPDB API key is available
       if (rpdbApiKey && result.metas) {
-        result.metas = processPosterUrls(result.metas, rpdbApiKey);
+        result.metas = processPosterUrls([...result.metas], rpdbApiKey);
       }
 
       return result;
@@ -209,7 +209,7 @@ export async function getAddonInterface(userId: string, db: D1Database) {
 
       // Process posters if RPDB API key is available
       if (rpdbApiKey && result.metas) {
-        result.metas = processPosterUrls(result.metas, rpdbApiKey);
+        result.metas = processPosterUrls([...result.metas], rpdbApiKey);
       }
 
       return result;
@@ -328,7 +328,7 @@ export async function handleAddonResource(request: any, userId: string) {
 
       // Process posters if RPDB API key is available
       if (rpdbApiKey && result.metas) {
-        result.metas = processPosterUrls(result.metas, rpdbApiKey);
+        result.metas = processPosterUrls([...result.metas], rpdbApiKey);
       }
 
       return new Response(JSON.stringify(result), {

--- a/packages/platforms/cloudflare/addon.ts
+++ b/packages/platforms/cloudflare/addon.ts
@@ -4,6 +4,8 @@ import packageJson from '../../../package.json';
 import { buildManifest, handleCatalogRequest } from '../../core/utils/manifestBuilder';
 import { logger } from '../../core/utils/logger';
 import { fetchMDBListCatalog, fetchListDetails } from '../../core/utils/mdblist';
+import { processPosterUrls } from '../../core/utils/posterUtils';
+import { loadUserRPDBApiKey } from '../../api/routes/rpdbRoutes';
 
 // Cache for builders to avoid multiple creations
 const addonCache = new Map();
@@ -71,6 +73,14 @@ async function processMDBListCatalog(args: any, userId: string): Promise<{ metas
         [metas[i], metas[j]] = [metas[j], metas[i]];
       }
       logger.debug(`Randomized ${metas.length} items for MDBList catalog ${catalogId}`);
+    }
+
+    // Get the user's RPDB API key
+    const rpdbApiKey = await loadUserRPDBApiKey(userId);
+
+    // Process posters if RPDB API key is available
+    if (rpdbApiKey && result.metas) {
+      result.metas = processPosterUrls(result.metas, rpdbApiKey);
     }
 
     return result;
@@ -147,7 +157,17 @@ export async function getAddonInterface(userId: string, db: D1Database) {
       }
 
       // Process regular catalogs
-      return handleCatalogRequest(args, userCatalogs, randomizedCatalogs);
+      const result = await handleCatalogRequest(args, userCatalogs, randomizedCatalogs);
+
+      // Get the user's RPDB API key
+      const rpdbApiKey = await loadUserRPDBApiKey(userId);
+
+      // Process posters if RPDB API key is available
+      if (rpdbApiKey && result.metas) {
+        result.metas = processPosterUrls(result.metas, rpdbApiKey);
+      }
+
+      return result;
     },
 
     // Meta handler - not implemented
@@ -182,7 +202,17 @@ export async function getAddonInterface(userId: string, db: D1Database) {
       const userConfig = await configManager.getConfig(userId);
       const randomizedCatalogs = userConfig.randomizedCatalogs || [];
 
-      return handleCatalogRequest(args, userCatalogs, randomizedCatalogs);
+      const result = await handleCatalogRequest(args, userCatalogs, randomizedCatalogs);
+
+      // Get the user's RPDB API key
+      const rpdbApiKey = await loadUserRPDBApiKey(userId);
+
+      // Process posters if RPDB API key is available
+      if (rpdbApiKey && result.metas) {
+        result.metas = processPosterUrls(result.metas, rpdbApiKey);
+      }
+
+      return result;
     },
   };
 
@@ -202,4 +232,117 @@ export function clearAddonCache(userId: string): void {
 export function clearAllAddonCache() {
   logger.debug('Clearing entire addon cache');
   addonCache.clear();
+}
+
+/**
+ * Helper function to parse catalog request parameters
+ */
+function parseCatalogRequest(path: string, request: any): CatalogRequest {
+  const parts = path.split('/');
+  const type = parts[0] || '';
+  const id = parts[1] || '';
+  const extra = parts[2] || '';
+
+  // Parse query parameters
+  const url = new URL(request.url);
+  const skip = parseInt(url.searchParams.get('skip') || '0', 10);
+  const limit = parseInt(url.searchParams.get('limit') || '100', 10);
+  const genre = url.searchParams.get('genre') || undefined;
+  const search = url.searchParams.get('search') || undefined;
+
+  return {
+    type,
+    id,
+    extra,
+    skip,
+    limit,
+    genre,
+    search,
+  };
+}
+
+/**
+ * Get manifest for a specific user
+ */
+async function getManifest(userId: string): Promise<Response> {
+  try {
+    // Get the user's catalogs
+    const userCatalogs = await configManager.getAllCatalogs(userId);
+    logger.info(`Found ${userCatalogs.length} catalogs for user ${userId}`);
+
+    // Build the manifest
+    const manifest = buildManifest(userId, version, description, userCatalogs);
+
+    return new Response(JSON.stringify(manifest), {
+      status: 200,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+  } catch (error) {
+    logger.error('Error getting manifest:', error);
+    return new Response('Server error', { status: 500 });
+  }
+}
+
+/**
+ * Main handler for addon requests
+ */
+export async function handleAddonResource(request: any, userId: string) {
+  try {
+    // Get the path from the request
+    const url = new URL(request.url);
+    const path = url.pathname.split(`/${userId}/`)[1];
+
+    // If no path, return the manifest
+    if (!path) {
+      return getManifest(userId);
+    }
+
+    // Handle catalog requests
+    if (path.startsWith('catalog/')) {
+      const catalogPath = path.replace('catalog/', '');
+      const catalogRequest = parseCatalogRequest(catalogPath, request);
+
+      // Check if it's a MDBList catalog request
+      if (catalogRequest.id && catalogRequest.id.startsWith('mdblist_')) {
+        const result = await processMDBListCatalog(catalogRequest, userId);
+
+        return new Response(JSON.stringify(result), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+      }
+
+      // Handle regular catalog requests
+      const userCatalogs = await configManager.getAllCatalogs(userId);
+      const userConfig = await configManager.getConfig(userId);
+      const randomizedCatalogs = userConfig.randomizedCatalogs || [];
+
+      const result = await handleCatalogRequest(catalogRequest, userCatalogs, randomizedCatalogs);
+
+      // Get the user's RPDB API key
+      const rpdbApiKey = await loadUserRPDBApiKey(userId);
+
+      // Process posters if RPDB API key is available
+      if (rpdbApiKey && result.metas) {
+        result.metas = processPosterUrls(result.metas, rpdbApiKey);
+      }
+
+      return new Response(JSON.stringify(result), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+    }
+
+    // If no matching route, return 404
+    return new Response('Not found', { status: 404 });
+  } catch (error) {
+    logger.error('Error handling addon request:', error);
+    return new Response('Server error', { status: 500 });
+  }
 }

--- a/packages/platforms/cloudflare/appConfig.ts
+++ b/packages/platforms/cloudflare/appConfig.ts
@@ -49,6 +49,12 @@ export const appConfig = {
      * @default 100
      */
     maxItemsMDBList: getEnvAsNumber('AIOCATALOGS_API_MAX_ITEMS_MDBLIST', 100),
+
+    /**
+     * Cache expiration time in days for RPDB API
+     * @default 7
+     */
+    cacheExpirationRPDB: getEnvAsNumber('AIOCATALOGS_API_CACHE_EXPIRATION_RPDB', 7),
   },
 
   /**

--- a/packages/platforms/cloudflare/configManager.ts
+++ b/packages/platforms/cloudflare/configManager.ts
@@ -311,7 +311,7 @@ export class CloudflareConfigManager extends BaseConfigManager {
   }
 
   // Save RPDB API key for a user
-  async saveRPDBAApiKey(userId: string, apiKey: string): Promise<boolean> {
+  async saveRPDBApiKey(userId: string, apiKey: string): Promise<boolean> {
     if (!this.database) {
       throw new Error('Database not initialized');
     }
@@ -370,7 +370,7 @@ export class CloudflareConfigManager extends BaseConfigManager {
   }
 
   // Load RPDB API key for a user
-  async loadRPDBAApiKey(userId: string): Promise<string | null> {
+  async loadRPDBApiKey(userId: string): Promise<string | null> {
     // Check cache first
     if (this.rpdbApiKeyCache.has(userId)) {
       const cachedKey = this.rpdbApiKeyCache.get(userId);

--- a/packages/platforms/cloudflare/configManager.ts
+++ b/packages/platforms/cloudflare/configManager.ts
@@ -7,6 +7,7 @@ import { logger } from '../../core/utils/logger';
 export class CloudflareConfigManager extends BaseConfigManager {
   private database: D1Database | null = null;
   private apiKeyCache: Map<string, string> = new Map<string, string>();
+  private rpdbApiKeyCache: Map<string, string> = new Map();
 
   constructor() {
     super();
@@ -206,12 +207,11 @@ export class CloudflareConfigManager extends BaseConfigManager {
     }
   }
 
-  // Add a new method to explicitly clear API key cache for a user
+  // Clear the API key cache for a user
   clearApiKeyCache(userId: string): void {
-    if (this.apiKeyCache.has(userId)) {
-      logger.info(`Clearing API key cache for user ${userId}`);
-      this.apiKeyCache.delete(userId);
-    }
+    this.apiKeyCache.delete(userId);
+    this.rpdbApiKeyCache.delete(userId);
+    logger.debug(`Cleared API key cache for user ${userId}`);
   }
 
   // Save MDBList API key for a user
@@ -272,46 +272,141 @@ export class CloudflareConfigManager extends BaseConfigManager {
 
   // Load MDBList API key for a user
   async loadMDBListApiKey(userId: string): Promise<string | null> {
+    // Check cache first
+    if (this.apiKeyCache.has(userId)) {
+      const cachedKey = this.apiKeyCache.get(userId);
+      logger.debug(`Using cached MDBList API key for user ${userId}`);
+      return cachedKey || null;
+    }
+
     if (!this.database) {
       throw new Error('Database not initialized');
     }
 
     try {
-      // First check the memory cache
-      if (this.apiKeyCache.has(userId)) {
-        const cachedKey = this.apiKeyCache.get(userId);
-        logger.debug(`Retrieved MDBList API key for user ${userId} from memory cache`);
-        return cachedKey || null;
-      }
-
       // Initialize the database if not already done
       await this.initDatabase();
 
+      // Get the API key from the database
       const result = await this.database
         .prepare('SELECT api_key FROM mdblist_api_keys WHERE user_id = ?')
         .bind(userId)
         .first();
 
       if (result && result.api_key) {
+        const apiKey = result.api_key as string;
         logger.debug(`Loaded MDBList API key for user ${userId} from database`);
 
-        // Cache for future requests
-        this.apiKeyCache.set(userId, result.api_key as string);
+        // Store in cache for future use
+        this.apiKeyCache.set(userId, apiKey);
 
-        return result.api_key as string;
+        return apiKey;
       }
-
-      logger.info(`No MDBList API key found for user ${userId}`);
-      return null;
     } catch (error) {
-      // Improved error handling
-      if (error instanceof Error) {
-        logger.error(`Error loading MDBList API key for user ${userId}: ${error.message}`, error);
-      } else {
-        logger.error(`Unknown error loading MDBList API key for user ${userId}:`, error);
-      }
-      return null;
+      logger.error(`Error loading MDBList API key for user ${userId}:`, error);
     }
+
+    logger.debug(`No MDBList API key found for user ${userId}`);
+    return null;
+  }
+
+  // Save RPDB API key for a user
+  async saveRPDBAApiKey(userId: string, apiKey: string): Promise<boolean> {
+    if (!this.database) {
+      throw new Error('Database not initialized');
+    }
+
+    try {
+      // Initialize the database if not already done
+      await this.initDatabase();
+
+      const now = Date.now();
+
+      // Check if an entry for this user already exists
+      const exists = await this.database
+        .prepare('SELECT 1 FROM rpdb_api_keys WHERE user_id = ?')
+        .bind(userId)
+        .first();
+
+      if (exists) {
+        // Update existing entry
+        await this.database
+          .prepare('UPDATE rpdb_api_keys SET api_key = ?, updated_at = ? WHERE user_id = ?')
+          .bind(apiKey, now, userId)
+          .run();
+      } else {
+        // Add new entry
+        await this.database
+          .prepare(
+            'INSERT INTO rpdb_api_keys (user_id, api_key, created_at, updated_at) VALUES (?, ?, ?, ?)'
+          )
+          .bind(userId, apiKey, now, now)
+          .run();
+      }
+
+      logger.info(`Saved RPDB API key for user ${userId}`);
+
+      // Update cache
+      this.rpdbApiKeyCache.set(userId, apiKey);
+      return true;
+    } catch (error) {
+      // Improved error handling with more detailed information
+      if (error instanceof Error) {
+        logger.error(`Error saving RPDB API key for user ${userId}: ${error.message}`, error);
+      } else {
+        logger.error(`Unknown error saving RPDB API key for user ${userId}:`, error);
+      }
+
+      // Try as fallback to store the API key in the in-memory cache
+      try {
+        this.rpdbApiKeyCache.set(userId, apiKey);
+        logger.info(`Saved RPDB API key for user ${userId} in memory cache as fallback`);
+        return true;
+      } catch (cacheError) {
+        logger.error(`Failed to save RPDB API key in memory cache: ${cacheError}`);
+        return false;
+      }
+    }
+  }
+
+  // Load RPDB API key for a user
+  async loadRPDBAApiKey(userId: string): Promise<string | null> {
+    // Check cache first
+    if (this.rpdbApiKeyCache.has(userId)) {
+      const cachedKey = this.rpdbApiKeyCache.get(userId);
+      logger.debug(`Using cached RPDB API key for user ${userId}`);
+      return cachedKey || null;
+    }
+
+    if (!this.database) {
+      throw new Error('Database not initialized');
+    }
+
+    try {
+      // Initialize the database if not already done
+      await this.initDatabase();
+
+      // Get the API key from the database
+      const result = await this.database
+        .prepare('SELECT api_key FROM rpdb_api_keys WHERE user_id = ?')
+        .bind(userId)
+        .first();
+
+      if (result && result.api_key) {
+        const apiKey = result.api_key as string;
+        logger.debug(`Loaded RPDB API key for user ${userId} from database`);
+
+        // Store in cache for future use
+        this.rpdbApiKeyCache.set(userId, apiKey);
+
+        return apiKey;
+      }
+    } catch (error) {
+      logger.error(`Error loading RPDB API key for user ${userId}:`, error);
+    }
+
+    logger.debug(`No RPDB API key found for user ${userId}`);
+    return null;
   }
 }
 

--- a/packages/platforms/cloudflare/index.ts
+++ b/packages/platforms/cloudflare/index.ts
@@ -9,6 +9,7 @@ import { rateLimit } from './middleware/rateLimit';
 import { logger, initLogger } from '../../core/utils/logger';
 import { appConfig } from './appConfig';
 import { fetchMDBListCatalog, fetchListDetails } from '../../core/utils/mdblist';
+import { saveRPDBConfig } from '../../api/routes/rpdbRoutes';
 
 // Configuration page (imported from separate file)
 import {
@@ -203,6 +204,12 @@ app.post('/configure/:userId/mdblist/add', async c => {
 app.post('/configure/:userId/mdblist/config', async c => {
   initConfigManager(c);
   return saveMDBListConfig(c);
+});
+
+// RPDB API configuration
+app.post('/configure/:userId/rpdb/config', async c => {
+  initConfigManager(c);
+  return saveRPDBConfig(c);
 });
 
 // MDBList manifest endpoint - needed for MDBList catalogs

--- a/packages/platforms/cloudflare/migrations/0002_add_rpdb_keys.sql
+++ b/packages/platforms/cloudflare/migrations/0002_add_rpdb_keys.sql
@@ -1,0 +1,12 @@
+-- Migration: Adding RPDB API Keys table
+-- Date: 2024-08-20
+
+-- RPDB API Keys for users
+CREATE TABLE IF NOT EXISTS rpdb_api_keys (
+  user_id TEXT PRIMARY KEY,
+  api_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+-- No need for an additional index on user_id since it's already a PRIMARY KEY 

--- a/packages/platforms/tests/rpdbPosters.test.ts
+++ b/packages/platforms/tests/rpdbPosters.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { processPosterUrls } from '../../core/utils/posterUtils';
+import { loadUserRPDBApiKey } from '../../api/routes/rpdbRoutes';
+import { MetaItem } from '../cloudflare/types';
+
+// Mock the posterUtils module
+vi.mock('../../core/utils/posterUtils', () => ({
+  processPosterUrls: vi.fn(),
+}));
+
+// Mock the rpdbRoutes module
+vi.mock('../../api/routes/rpdbRoutes', () => ({
+  loadUserRPDBApiKey: vi.fn(),
+}));
+
+// Mock the configManager
+vi.mock('../cloudflare/configManager', () => ({
+  configManager: {
+    loadMDBListApiKey: vi.fn().mockResolvedValue('mock-api-key'),
+    getAllCatalogs: vi.fn().mockResolvedValue([]),
+    getConfig: vi.fn().mockResolvedValue({ randomizedCatalogs: [] }),
+    setDatabase: vi.fn(),
+  },
+}));
+
+// Mock the mdblist utilities
+vi.mock('../../core/utils/mdblist', () => ({
+  fetchMDBListCatalog: vi.fn().mockResolvedValue({ metas: [] }),
+  fetchListDetails: vi.fn(),
+}));
+
+// Mock the manifestBuilder
+vi.mock('../../core/utils/manifestBuilder', () => ({
+  buildManifest: vi.fn().mockReturnValue({}),
+  handleCatalogRequest: vi.fn().mockResolvedValue({ metas: [] }),
+}));
+
+// Mock logger
+vi.mock('../../core/utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Test the integration between addon.ts and the RPDB poster functionality
+describe('RPDB Posters Integration', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should apply RPDB posters when processing catalog requests', async () => {
+    // Create mock data
+    const mockUserId = 'test-user';
+    const mockApiKey = 'test-rpdb-api-key';
+    const mockMetas = [
+      {
+        id: 'tt1234567',
+        type: 'movie',
+        name: 'Test Movie 1',
+        poster: 'https://example.com/poster1.jpg',
+      },
+      {
+        id: 'tt7654321',
+        type: 'movie',
+        name: 'Test Movie 2',
+        poster: 'https://example.com/poster2.jpg',
+      },
+    ];
+
+    // Mock the loadUserRPDBApiKey to return our test API key
+    vi.mocked(loadUserRPDBApiKey).mockResolvedValue(mockApiKey);
+
+    // Mock processPosterUrls to return processed metas
+    const processedMetas = [
+      {
+        id: 'tt1234567',
+        type: 'movie',
+        name: 'Test Movie 1',
+        poster: 'https://rpdb.com/poster1.jpg',
+      },
+      {
+        id: 'tt7654321',
+        type: 'movie',
+        name: 'Test Movie 2',
+        poster: 'https://rpdb.com/poster2.jpg',
+      },
+    ];
+    vi.mocked(processPosterUrls).mockReturnValue(processedMetas);
+
+    // Mock handleCatalogRequest to return metas
+    const { handleCatalogRequest } = await import('../../core/utils/manifestBuilder');
+    vi.mocked(handleCatalogRequest).mockResolvedValue({ metas: mockMetas });
+
+    // Create a mock for Response constructor
+    const mockResponseJson = vi.fn();
+    const mockResponse = {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      json: mockResponseJson,
+    };
+    global.Response = vi.fn().mockImplementation(() => mockResponse) as any;
+
+    // Import the handleAddonResource function after all mocks are set up
+    const { handleAddonResource } = await import('../cloudflare/addon');
+
+    // Create a mock request
+    const mockRequest = {
+      url: `http://example.com/${mockUserId}/catalog/movie/regular_catalog.json`,
+    };
+
+    // Call the handleAddonResource function
+    await handleAddonResource(mockRequest, mockUserId);
+
+    // Verify API key was loaded
+    expect(loadUserRPDBApiKey).toHaveBeenCalledWith(mockUserId);
+
+    // Check that processPosterUrls was called
+    expect(processPosterUrls).toHaveBeenCalled();
+  });
+});

--- a/packages/types/common.ts
+++ b/packages/types/common.ts
@@ -46,6 +46,10 @@ export interface CatalogRequest {
   type: string; // Content type (e.g. 'movie', 'series')
   id: string; // Catalog ID
   extra?: any; // Additional parameters
+  skip?: number; // Number of items to skip
+  limit?: number; // Maximum number of items to return
+  genre?: string; // Filter by genre
+  search?: string; // Search query
 }
 
 export interface CatalogResponse {

--- a/templates/addonInstallComponent.ts
+++ b/templates/addonInstallComponent.ts
@@ -21,10 +21,10 @@ export function getAddonInstallationHTML(userId: string, baseUrl: string): strin
     <div class="rounded-lg border bg-card p-6 shadow-card">
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
         <h2 class="text-xl font-semibold flex items-center">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-primary mr-2">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-primary mr-2">
             <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
             <polyline points="3.29 7 12 12 20.71 7"></polyline>
-            <line x1="12" y1="22" y2="12"></line>
+            <line x1="12" y1="22" x2="12" y2="12"></line>
           </svg>
           Install Your Addon
         </h2>

--- a/templates/addonInstallComponent.ts
+++ b/templates/addonInstallComponent.ts
@@ -21,8 +21,10 @@ export function getAddonInstallationHTML(userId: string, baseUrl: string): strin
     <div class="rounded-lg border bg-card p-6 shadow-card">
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
         <h2 class="text-xl font-semibold flex items-center">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-primary mr-2">
-            <path d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4"></path>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-primary mr-2">
+            <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+            <polyline points="3.29 7 12 12 20.71 7"></polyline>
+            <line x1="12" y1="22" y2="12"></line>
           </svg>
           Install Your Addon
         </h2>

--- a/templates/configPage.ts
+++ b/templates/configPage.ts
@@ -4,16 +4,17 @@
  * This file contains HTML templates that can be used by Cloudflare and future implementations.
  * It serves as an integration point for the smaller, more maintainable component files.
  */
-import { getMDBListSearchFormHTML } from './mdblistTemplates';
+import { getHTMLHead, getBodyOpeningHTML, getBodyClosingHTML } from './pageStructureComponents';
 import { getConfigPageHeaderHTML } from './configPageHeader';
-import { getAddCatalogFormHTML } from './addCatalogComponent';
-import { getMDBListApiConfigHTML } from './mdblistComponent';
-import { getCatalogListHTML } from './catalogListComponent';
-import { getAddonInstallationHTML } from './addonInstallComponent';
 import { getSponsorBannerHTML } from './sponsorComponent';
+import { getAddCatalogFormHTML } from './addCatalogComponent';
+import { getCatalogListHTML } from './catalogListComponent';
+import { getMDBListApiConfigHTML } from './mdblistComponent';
+import { getMDBListSearchFormHTML } from './mdblistTemplates';
+import { getRPDBApiConfigHTML } from './rpdbComponent';
+import { getAddonInstallationHTML } from './addonInstallComponent';
 import { getFooterHTML } from './footerComponent';
 import { getPageScriptsHTML } from './pageScriptsComponent';
-import { getHTMLHead, getBodyOpeningHTML, getBodyClosingHTML } from './pageStructureComponents';
 import { getHomePageHTML } from './homePageTemplate';
 export { convertStremioUrl } from './utilities';
 
@@ -28,10 +29,11 @@ export function getConfigPageHTML(
   error: string = '',
   isCloudflare: boolean = false,
   packageVersion: string = '1.0.0',
-  apiKey: string = ''
+  mdblistApiKey: string = '',
+  rpdbApiKey: string = ''
 ) {
   // Add MDBList search form if API key is available
-  const mdblistSearchForm = apiKey ? getMDBListSearchFormHTML(userId) : '';
+  const mdblistSearchForm = mdblistApiKey ? getMDBListSearchFormHTML(userId) : '';
 
   // Build the page by combining the components
   return `
@@ -47,7 +49,8 @@ export function getConfigPageHTML(
           ${getCatalogListHTML(userId, catalogs)}
         </div>
         <div class="md:col-span-12 lg:col-span-4 space-y-6">
-          ${getMDBListApiConfigHTML(userId, apiKey)}
+          ${getMDBListApiConfigHTML(userId, mdblistApiKey)}
+          ${getRPDBApiConfigHTML(userId, rpdbApiKey)}
           ${mdblistSearchForm}
           ${getAddonInstallationHTML(userId, baseUrl)}
         </div>

--- a/templates/mdblistComponent.ts
+++ b/templates/mdblistComponent.ts
@@ -29,7 +29,7 @@ export function getMDBListApiConfigHTML(userId: string, apiKey: string): string 
                   <path d="M12 17h.01"></path>
                 </svg>
                 <span class="hidden group-hover:block absolute bottom-full mb-2 left-1/2 transform -translate-x-1/2 w-60 p-2 bg-card rounded shadow-lg text-xs text-muted-foreground border border-border">
-                  Required for RPDB poster functionality. Your API key will be stored securely and used only for retrieving posters.
+                  Required for MDBList search and Top 100 lists functionality. Your API key will be stored securely and used only for retrieving posters.
                 </span>
               </span>
             </label>

--- a/templates/rpdbComponent.ts
+++ b/templates/rpdbComponent.ts
@@ -1,26 +1,25 @@
 /**
- * MDBList API related components for the configuration page
+ * Component for the RPDB API key configuration form
  */
 
 /**
- * Creates the HTML for the MDBList API configuration form
+ * Creates the HTML for the RPDB API key configuration form
  */
-export function getMDBListApiConfigHTML(userId: string, apiKey: string): string {
+export function getRPDBApiConfigHTML(userId: string, apiKey: string): string {
   return `
-  <section>
-    <div class="rounded-lg border bg-card p-6 shadow-card">
-      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4">
-        <h2 class="text-xl font-semibold flex items-center">
+  <section id="rpdbConfig" class="rounded-lg border bg-card shadow-card">
+    <div class="p-6">
+      <div class="flex items-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-primary mr-2">
             <path d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4"></path>
           </svg>
-          MDBList Configuration
-        </h2>
+        <h2 class="text-xl font-semibold">RPDB Configuration</h2>
       </div>
-      <form method="POST" action="/configure/${userId}/mdblist/config" class="animate-enter">
-        <div class="grid gap-4">
+      
+      <form method="POST" action="/configure/${userId}/rpdb/config" class="space-y-4">
+        <div class="grid gap-3">
           <div class="grid gap-2">
-            <label for="apiKey" class="text-sm font-medium flex items-center">
+            <label for="rpdbApiKey" class="text-sm font-medium flex items-center">
               API Key
               <span class="relative ml-1.5 group">
                 <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-muted-foreground cursor-help">
@@ -34,12 +33,13 @@ export function getMDBListApiConfigHTML(userId: string, apiKey: string): string 
               </span>
             </label>
             <div class="relative">
-              <input
-                type="text"
-                id="apiKey"
-                name="apiKey"
+              <input 
+                type="text" 
+                id="rpdbApiKey" 
+                name="apiKey" 
+                autocomplete="off"
+                placeholder="Enter your RPDB API Key" 
                 value="${apiKey}"
-                placeholder="Enter your MDBList API Key"
                 class="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 pr-10"
               />
               <div class="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground">
@@ -48,7 +48,8 @@ export function getMDBListApiConfigHTML(userId: string, apiKey: string): string 
                   <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
                 </svg>
               </div>
-            </div> 
+            </div>
+          </div>
             <p class="text-sm text-muted-foreground flex items-center gap-1">
               <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-primary">
                 <circle cx="12" cy="12" r="10"></circle>
@@ -56,15 +57,14 @@ export function getMDBListApiConfigHTML(userId: string, apiKey: string): string 
                 <path d="M12 8h.01"></path>
               </svg>
               Get your free API key from 
-              <a href="https://mdblist.com/preferences/" target="_blank" class="text-primary hover:underline inline-flex items-center">
-                MDBList 
+              <a href="https://ratingposterdb.com/" target="_blank" class="text-primary hover:underline inline-flex items-center">
+                RPDB 
                 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="ml-1">
                   <path d="M7 7h10v10"></path>
                   <path d="M7 17 17 7"></path>
                 </svg>
               </a>
             </p>
-          </div>
           <div class="flex justify-end">
             <button
               type="submit"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,6 +20,7 @@ AIOCATALOGS_TRUSTED_ORIGINS = "https://aio.pantelx.com, https://aiocatalogs.jqrw
 AIOCATALOGS_API_RATE_LIMIT = true
 AIOCATALOGS_API_MAX_REQUESTS = 50 # requests per minute
 AIOCATALOGS_API_MAX_ITEMS_MDBLIST = 100 # maximum number of items fetched from MDBList API
+AIOCATALOGS_API_CACHE_EXPIRATION_RPDB = 30 # cache expiration time in days for RPDB API
 
 LOG_LEVEL = "info" # debug, info, warn, error, or none
 LOG_ENABLE_TIMESTAMPS = true
@@ -43,6 +44,7 @@ AIOCATALOGS_TRUSTED_ORIGINS = "http://localhost:8787" # comma-separated list of 
 AIOCATALOGS_API_RATE_LIMIT = false
 AIOCATALOGS_API_MAX_REQUESTS = 5 # requests per minute
 AIOCATALOGS_API_MAX_ITEMS_MDBLIST = 10 # maximum number of items fetched from MDBList API
+AIOCATALOGS_API_CACHE_EXPIRATION_RPDB = 1 # cache expiration time in days for RPDB API
 
 LOG_LEVEL = "debug" # debug, info, warn, error, or none
 LOG_ENABLE_TIMESTAMPS = true


### PR DESCRIPTION
resolves #37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring and saving an RPDB (Rating Poster Database) API key per user.
  - Integrated RPDB poster URL processing into catalog responses, enabling enhanced poster images when an RPDB API key is present.
  - Added a new configuration form for RPDB API keys in the user settings page.

- **Improvements**
  - Catalog requests now support pagination, genre filtering, and search via new query parameters.
  - Poster URL caching for RPDB is now configurable with cache expiration settings.

- **Bug Fixes**
  - Improved error handling and user feedback during RPDB API key validation and saving.

- **Documentation**
  - Updated configuration instructions and added tooltips for API key input fields.

- **Tests**
  - Added comprehensive tests for RPDB API key management and poster URL processing.

- **Chores**
  - Database migration added for storing RPDB API keys.
  - Updated environment variables for RPDB cache expiration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->