### PR TITLE
fix: add landscape cover art support for MDBLists within Omni

### DIFF
--- a/packages/core/utils/mdblist.ts
+++ b/packages/core/utils/mdblist.ts
@@ -43,6 +43,7 @@ export interface StremioMeta {
   name: string;
   type: string;
   poster?: string;
+  background?: string;
   genres?: string[];
   releaseInfo?: string;
 }
@@ -323,6 +324,7 @@ export function convertToStremioMeta(items: {
         name: movie.title,
         type: 'movie',
         poster: `https://images.metahub.space/poster/small/${movie.imdb_id}/img`,
+        background: `https://images.metahub.space/background/small/${movie.imdb_id}/img`,
         releaseInfo: movie.release_year ? `${movie.release_year}` : undefined,
       });
     });
@@ -338,6 +340,7 @@ export function convertToStremioMeta(items: {
         name: show.title,
         type: 'series',
         poster: `https://images.metahub.space/poster/small/${show.imdb_id}/img`,
+        background: `https://images.metahub.space/background/small/${show.imdb_id}/img`,
         releaseInfo: show.release_year ? `${show.release_year}--` : undefined,
       });
     });


### PR DESCRIPTION
fixes stretched cover art in Omni top 10 catalogs while using MDBLists from aiocatalogs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for background images for movies and shows, allowing display of a dedicated background alongside existing poster images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->